### PR TITLE
Add support for inputless endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # @aesop-fables/triginta
 
-`triginta` is a lightweight framework that wraps the basic infrastructure usages of AWS Lambda (SQS, Kinesis, etc.). For APIs, see our `API framework`. It aims
-to conventionalize logging, error handling, and X-Ray integration.
+`triginta` is a lightweight framework that wraps the basic infrastructure usages of AWS Lambda (SQS, Kinesis, etc.) and is entirely based on top of Middyjs. 
 
 ## Installation
 ```
@@ -11,37 +10,7 @@ npm install @aesop-fables/triginta
 yarn add @aesop-fables/triginta
 ```
 
-## Supported Lambdas
-The following can be created via the `ILambdaFactory` interface:
+## Docs
 
-1. SQS Lambdas (`createSqsLambda`)
-2. S3 Lambdas (`createS3Lambda`)
-3. Kinesis Lambdas (`createKinesisLambda`)
-
-## Known issues
-We're missing unit tests, logging, error handling, middleware support, and X-Ray integration. This will all come soon - I just wanted to get the basic structure published.
-
-## Example
-```typescript
-// index.ts
-interface MyQueuedMessage {
-  message: string;
-}
-
-class MyLambda implements IHandler<MyQueuedMessage> {
-  async handle(message: MyQueuedMessage): Promise<void> {
-    console.log('HELLO, WORLD!');
-    console.log(JSON.stringify(message, null, 2));
-  }
-}
-
-// obviously you need to register all of your stuff
-const container = bootstrap();
-// triginta doesn't depend on containr but it abstracts out the creation of your handler
-// so that you can easily plug it in (see the `factory` property)
-const lambdaFactory = container.get<ILambdaFactory>();
-
-export const handler = lambdaFactory.createSqsLambda<MyLambda>({
-  factory: () => container.get<MyLambda>('lambda'),
-});
-```
+Docs are coming. In the meantime, we recommend you checkout the docs from middyjs and our example repo: 
+https://github.com/aesop-fables/triginta-example

--- a/src/HttpLambdaServices.ts
+++ b/src/HttpLambdaServices.ts
@@ -1,3 +1,4 @@
 export const HttpLambdaServices = {
   HttpLambdaFactory: 'HttpLambdaFactory',
+  HttpResponseGenerator: 'HttpResponseGenerator',
 };

--- a/src/IHandler.ts
+++ b/src/IHandler.ts
@@ -1,4 +1,9 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface IHandler<Message, Event = any, Return = void> {
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export interface IEventHandler<Event = any, Return = void> {
+  handle(event: Event): Promise<Return>;
+}
+
+export interface IMessageHandler<Message, Event = any, Return = void> {
   handle(message: Message, event: Event): Promise<Return>;
 }

--- a/src/IHttpEndpoint.ts
+++ b/src/IHttpEndpoint.ts
@@ -1,4 +1,4 @@
 import { APIGatewayProxyEventV2 } from 'aws-lambda';
-import { IHandler } from './IHandler';
+import { IMessageHandler } from './IHandler';
 
-export interface IHttpEndpoint<Input, Output> extends IHandler<Input, APIGatewayProxyEventV2, Output> {}
+export interface IHttpEndpoint<Input, Output> extends IMessageHandler<Input, APIGatewayProxyEventV2, Output> {}

--- a/src/IHttpEndpoint.ts
+++ b/src/IHttpEndpoint.ts
@@ -1,4 +1,6 @@
 import { APIGatewayProxyEventV2 } from 'aws-lambda';
-import { IMessageHandler } from './IHandler';
+import { IEventHandler, IMessageHandler } from './IHandler';
+
+export interface IHttpEventHandler<Output = void> extends IEventHandler<APIGatewayProxyEventV2, Output> {}
 
 export interface IHttpEndpoint<Input, Output> extends IMessageHandler<Input, APIGatewayProxyEventV2, Output> {}

--- a/src/__tests__/Middleware.test.ts
+++ b/src/__tests__/Middleware.test.ts
@@ -80,7 +80,7 @@ describe('createHttpLambda', () => {
       configuredRoute: getRoute(CreateStatusAlertEndpoint) as IConfiguredRoute,
       container,
       body,
-      path: 'testpath',
+      rawPath: 'testpath',
     });
 
     const endpointMetadata = getRoute(CreateStatusAlertEndpoint) as IConfiguredRoute;

--- a/src/__tests__/invokeHttpHandler.test.ts
+++ b/src/__tests__/invokeHttpHandler.test.ts
@@ -37,7 +37,7 @@ describe('createApiGatewayEvent', () => {
             method: 'GET',
             route: '/test/hello',
           },
-          path: '/test/hello',
+          rawPath: '/test/hello',
         });
 
         expect(event.rawPath).toBe('/test/hello');
@@ -51,7 +51,7 @@ describe('createApiGatewayEvent', () => {
             method: 'GET',
             route: '/test/hello',
           },
-          path: '/test/hello?foo=bar&bar=foo',
+          rawPath: '/test/hello?foo=bar&bar=foo',
         });
 
         expect(event.rawPath).toBe('/test/hello?foo=bar&bar=foo');
@@ -69,7 +69,7 @@ describe('createApiGatewayEvent', () => {
             method: 'GET',
             route: '/params/{param1}/blah/{param2}',
           },
-          path: '/params/hello/blah/world',
+          rawPath: '/params/hello/blah/world',
         });
 
         expect(event.rawPath).toBe('/params/hello/blah/world');
@@ -90,7 +90,7 @@ describe('createApiGatewayEvent', () => {
             method: 'GET',
             route: '/test',
           },
-          path: '/test',
+          rawPath: '/test',
         });
 
         expect(event.version).toBe('2.0');
@@ -106,7 +106,7 @@ describe('createApiGatewayEvent', () => {
             method: 'GET',
             route: '/test',
           },
-          path: '/test',
+          rawPath: '/test',
         });
 
         expect(event.requestContext?.accountId).toBe('888888888888');
@@ -127,7 +127,7 @@ describe('createApiGatewayEvent', () => {
               method: 'GET',
               route: '/test',
             },
-            path: '/test',
+            rawPath: '/test',
           });
 
           expect(event.requestContext?.http?.method).toBe('GET');
@@ -147,7 +147,7 @@ describe('createApiGatewayEvent', () => {
             method: 'GET',
             route: '/test',
           },
-          path: '/test',
+          rawPath: '/test',
         });
 
         const headers = event.headers ?? {};
@@ -172,7 +172,7 @@ describe('createApiGatewayEvent', () => {
         method: 'POST',
         route: '/test',
       },
-      path: '/test',
+      rawPath: '/test',
       body,
     });
 
@@ -213,7 +213,7 @@ describe('invokeHttpHandler', () => {
           route: '/triginta/middlware/json',
         },
         container,
-        path: '/triginta/middlware/json?foo=bar',
+        rawPath: '/triginta/middlware/json?foo=bar',
         body,
       })) as APIGatewayProxyStructuredResultV2;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
-import { IMessageHandler } from './IHandler';
-import { IHttpEndpoint } from './IHttpEndpoint';
-
+export * from './IHandler';
+export * from './IHttpEndpoint';
 export * from './Decorators';
 export * from './HttpLambda';
 export * from './HttpLambdaServices';
@@ -8,5 +7,3 @@ export { default as RouteRegistry, IRouteRegistry } from './RouteRegistry';
 export * from './invokeHttpHandler';
 export * from './IConfiguredRoute';
 export * from './TrigintaConfig';
-
-export { IMessageHandler, IHttpEndpoint };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
-import 'reflect-metadata';
-import { IHandler } from './IHandler';
+import { IMessageHandler } from './IHandler';
 import { IHttpEndpoint } from './IHttpEndpoint';
 
 export * from './Decorators';
@@ -10,4 +9,4 @@ export * from './invokeHttpHandler';
 export * from './IConfiguredRoute';
 export * from './TrigintaConfig';
 
-export { IHandler, IHttpEndpoint };
+export { IMessageHandler, IHttpEndpoint };


### PR DESCRIPTION
Example:

```typescript
@httpGet('/http-lambda/initialize/without-input')
class InitializeWithoutInputEndpoint implements IHttpEventHandler<string> {
  // eslint-disable-next-line @typescript-eslint/no-unused-vars
  async handle(event: APIGatewayProxyEventV2): Promise<string> {
    return `Hello, ${event.headers['x-message']}`;
  }
}
```